### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ The Lua Community Blog
 
 More info:  [Opening Post](http://lua.space/general/blog-opening-and-contribution-guide)
 
-##Yay, awesome, what is this blog for?
+## Yay, awesome, what is this blog for?
 Yes, that's an important question! Please notice that we don't have any affilitation with the official Lua team, but we intend to be a central hub for distributing news, technical posts and general discussions on everything related to Lua. Or, as the name says, a Lua space. Subscribe to our [RSS feed](http://feeds.feedburner.com/Luaspace) if you wish to be notified when there's new content.
 
 ## Becoming a writer
@@ -49,7 +49,7 @@ This blog was created to promote the use of Lua on various levels, both personal
 * Other domains not listed are welcome! We are pretty excited to see Lua being used in different ways!
 	* If you are unsure if the topic would be well received, [open an issue at github](https://github.com/Etiene/lua.space/issues) and ask around :) 
 
-###Format
+### Format
  Follow normal conventions for writing a google article such as having an introduction, adding references whenever possible etc. All posts should be Lua related in some level. Try to raise interesting discussions :) Besides that, the format is pretty flexible. In case you are unsure, you'll find some examples of types of article below. 
  
 #### Some example formats: 

--- a/posts/art/making-music-in-lua.md
+++ b/posts/art/making-music-in-lua.md
@@ -1,15 +1,15 @@
-##Writing code as an artistic practice
+## Writing code as an artistic practice
 Live coding is a hard thing to define but essentially it is about writing code to generate improvised music and/or visuals. Frequently, all the code manipulation is projected or streamed. There is a big, diverse, friendly and a well organized [community](http://toplap.org/) around this artistic movement. Also, it is inclusive and accessible to all, a lot of live coding environments can be used for free or you can write your own. Popular live coding languages includes: [SuperCollider](http://supercollider.github.io/), [Sonic Pi](http://sonic-pi.net/), [Fluxus](http://www.pawfal.org/fluxus/), [ixi lang](http://www.ixi-audio.net/ixilang/), [Tidal](http://slab.org/tidal/), [Gibber](http://charlie-roberts.com/gibber/), etc.
 
-##Using Lua in a musical context
+## Using Lua in a musical context
 Why use Lua for live coding if there are cooler and more developed frameworks?
 Well, that was the first question that I had to answer when I decided to write a musical live coding environment in Lua, now named [Moonlet](https://github.com/elihugarret/Moonlet). It is not the first Lua live coding framework, maybe the best known is [LuaAV](http://lua-av.mat.ucsb.edu/blog/) but the project seems dead. There is also [Praxis](https://github.com/createuniverses/praxis) and [Worp](http://worp.zevv.nl/), but you have to compile a lot of things and I hate to compile a lot of things, in this case Moonlet is portable (only for Windows users).
 Writing your own environment is like making your own musical instrument and Lua lets me to express easily (with a few lines of code) ideas and structures needed to create the music that I want. I will explain that in future posts entries and how developing some musical concepts in Lua is easier and more readable compared with other languages.
 
-##Experiments
+## Experiments
 I made a few videos showing how Moonlet behaves with diverse Lua libraries.
 
-###String interpolation experiment
+### String interpolation experiment
 Lua is a minimal programming language, and many "popular" features are not included in it. But I think that the "less is more" Lua philosophy is great, handling with a restricted environment makes you more creative as everything in the language is well designed and not just a pile of features. When I found the [f-strings](https://github.com/hishamhm/f-strings) module made by [Hisham Muhammad](https://github.com/hishamhm) that implements python-like string interpolation in Lua, I decided to make something with it:   
 
 <br/>
@@ -28,7 +28,7 @@ In the video basically Moonlet sends MIDI messages in real-time to an external s
 		_ _ 65 _ _ 60 _ 67
 		]] ):n()
 
-###S-Lua experiment
+### S-Lua experiment
 I love functional programming languages and, obviously, parentheses. Lua has the coolest functional features and the LuaJIT ffi library lets you write and call C stuff within Lua code. If you think this is really great just hold on and check [this](https://github.com/eugeneia/s-lua). Yes, s-expressions for Lua, you must also read this: [Experimental Meta-Programming for Lua](http://mr.gy/blog/lua-meta-programming.html) by Max Rottenkolber.
 In this experiment notes and sound samples are represented as s-expressions:   
    
@@ -56,7 +56,7 @@ This snippet of code is a lispy step sequencer:
 	]]
 	
 
-##Conclusions
+## Conclusions
 There are a lot of things that I left out about Moonlet, like how it works or how to install it. I will write about that in the near future. The purpose of this post is to show that Lua is fully capable for music handling in a live coding context.
 Here is an example of a complete track written entirely in Lua and recorded live:
 

--- a/posts/general/blog-opening-and-contribution-guide.md
+++ b/posts/general/blog-opening-and-contribution-guide.md
@@ -1,4 +1,4 @@
-##How it all started
+## How it all started
 It's always very difficult to write the opening post of a blog, but I guess I should start by how the idea of creating this blog came up. It all started after I read a blog post on [Model View Culture](https://modelviewculture.com) called [C is Manly, Python is for “n00bs”: How False Stereotypes Turn Into Technical “Truths”](https://modelviewculture.com/pieces/c-is-manly-python-is-for-n00bs-how-false-stereotypes-turn-into-technical-truths). It tells us how myths and stereotypes about programming languages damage our area as developers. Beliefs of what are "toy languages" as opposed to "real languages" are often nothing more than social constructs. This stops significant technology of getting widespread, demotivates excellent developers and proliferates cargo-cult programming. 
 
 <center>
@@ -19,10 +19,10 @@ As a Lua developer and advocate, this article resonated with me on a deep level.
 
 During my rant, a group of other Lua developers that had similar feelings started engaging on what we could do to contribute to Lua in terms of community and how we could show our appreciation for the language. That's when the idea for the blog came up. After a long list of tweets, a secret chat and some exchange of ideas, I started building this blog (in Lua, of course! ^_^). You may check the source [here](https://github.com/Etiene/lua.space). 
 
-##Yay, awesome, but what is this blog for?
+## Yay, awesome, but what is this blog for?
 Yes, that's an important question! Please notice that we don't have any affilitation with the official Lua team, but we intend to be a central hub for distributing news, technical posts and general discussions on everything related to Lua. Or, as the name says, a Lua space. Subscribe to our [RSS feed](http://feeds.feedburner.com/Luaspace) if you wish to be notified when there's new content.
 
-##Share your knowledge
+## Share your knowledge
 I am super excited! Are you super excited? Share your knowledge by contributing with Lua related posts! 
 
 All posts are written in markdown and are contained in our [git repository](https://github.com/Etiene/lua.space). Inside the `posts` directory you'll find one or multiple other directories which are the categories of our posts. This one, for example, is in [general](https://github.com/Etiene/lua.space/tree/master/posts/general).  
@@ -48,7 +48,7 @@ This blogs support syntax highlight provided by [highlight.js](http://highlightj
 		print("You are awesome!")
 	end
 
-##Awesome people
+## Awesome people
 Special thanks go to [Pierre Chapuis](https://twitter.com/pchapuis) ([Lua Toolbox](https://lua-toolbox.com/)), for the domain name, [undef](https://twitter.com/undefdev) ([quadrant](http://quadrantgame.com/)) for the initial engagement and next contributions as a writer, [Bogdan Marinescu](https://twitter.com/bogdanm78) ([eLua](http://eluaproject.net)), [Mathäus Mendel](https://twitter.com/mathausmendel) ([OpenTibia](https://github.com/opentibia/ )) and [Elihu Garret](https://twitter.com/Mr_Auk) ([Moonlet](https://github.com/elihugarret/Moonlet)) for exchanging ideas and helping this come to reality, and every future writer of this blog!
 
 Cheers!

--- a/posts/general/community-news-1-and-meetup-at-fosdem.md
+++ b/posts/general/community-news-1-and-meetup-at-fosdem.md
@@ -6,7 +6,7 @@ I'll be present, giving a talk, but I'll also make sure to cover the highlights 
 
 Happy new year!
 
-##Lastest News & Releases
+## Lastest News & Releases
 
 ### Dec 25th - OpenResty 1.9.7.1 released
 [Source [BSD]](https://github.com/openresty/ngx_openresty) | [Website](https://openresty.org/)
@@ -41,7 +41,7 @@ Just recently I noticed we had two groups on facebook for the Lua programming la
 So we decided to open one of them to international members and switch the default language to English.  
 
 
-##Conference & Meet-up!
+## Conference & Meet-up!
 Write down on your calendars: on January 30th 2016 we will be meeting at FOSDEM, where a Lua Dev room will be hosted with great talks, great people and great discussions about what's coming next!
 
 
@@ -53,19 +53,19 @@ It will be held at Brussels, Belgium, on January 30th-31st 2016.
 Last yeat we had a quick Bird of Feathers room for our community to meet and this year we will have a full devroom only for Lua-related talks, thanks to the organizers [Hisham Muhammad](http://twitter.com/hisham_hm) (htop / GoboLinux / LuaRocks) and [Pierre Chapuis](https://twitter.com/pchapuis) (Lua Toolbox).
 Our devroom will be on the afternoon of the 30th and this is the current talk schedule with the abstracts (some were summarized):
 
-###14:00 - How awesome ended up with Lua and not Guile - Retrospective of the awesome window manager
-####Julien Danjou
+### 14:00 - How awesome ended up with Lua and not Guile - Retrospective of the awesome window manager
+#### Julien Danjou
 During the year 2008, the awesome window manager jumped in and picked a programming language to allow its users to extend their configuration beyond the limit of the possible. History shows that Lua was picked and Guile completely ignored. Fast forward 7 years later: awesome is still used by tens of thousands of geeks around the globe who write Lua every day. This talk is going to relate how awesome ended up with Lua, how wonderful and terrible it was, and how and why Guile was discarded.
 
 
-###15:00 - elasticsearch-lua - Building Lua Applications on Top of Elasticsearch	
-####Pablo Musa
+### 15:00 - elasticsearch-lua - Building Lua Applications on Top of Elasticsearch	
+#### Pablo Musa
 [Read full abstract](https://fosdem.org/2016/schedule/event/building_lua_applications_on_top_of_elasticsearch/)
 
 Elasticsearch is a distributed and scalable data platform written in Java that, besides the transport protocol (Java to Java), offers a very complete REST API accessed through JSON. This talk will cover the details of the Elasticsearch client we built for Lua as a part of the GSoC program in the LabLua organization.
 
-###15:20 - Continuous Integration with Lua	
-####Enrique García	
+### 15:20 - Continuous Integration with Lua	
+#### Enrique García	
 Continuous Integration with Lua? Is it worth it? Is there at least a modern way to do it?
 
 I have implemented some reasonably popular open-source Lua libraries, like middleclass.lua & inspect.lua. I would like to share how I make my life easier with automatic testing & automation.
@@ -76,12 +76,12 @@ On this talk I will:
 * Exemplify my current method of configuring travis+github in an opensource project
 * Talk about other options & alternatives
 
-###15:50 - Web development in Lua - Introducing Sailor, an MVC framework	
-####Etiene	Dalcol 
+### 15:50 - Web development in Lua - Introducing Sailor, an MVC framework	
+#### Etiene	Dalcol 
 Lua is a very fast and powerful scripting language that can be easily embeddable. It has been shining in industries like game development, for example. Lua is also an excellent tool as a general purpose language and can be used to develop robust applications. Its use in web developments, however, despite its great potential and incredible benchmarks, needs to be more widespread. This talk will mention the current state of Lua in web development, show some benchmarks, compare existing tools and teach developers how to get started with Sailor, an MVC web framework written in Lua.
 
-###16:10 - Lua: the Language of the Web?	
-####Paul Cuthbertson	
+### 16:10 - Lua: the Language of the Web?	
+#### Paul Cuthbertson	
 An introduction to the Starlight project.
 
 * A comparison of Lua and JavaScript
@@ -90,28 +90,28 @@ An introduction to the Starlight project.
 * Examples of interacting with the DOM from Lua
 * Walkthrough of using Starlight in your build pipeline
 
-###16:40 - Hammerspoon - OS X automation with Lua	
-####Peter van Dijk	
+### 16:40 - Hammerspoon - OS X automation with Lua	
+#### Peter van Dijk	
 [Read full abstract](https://fosdem.org/2016/schedule/event/hammerspoon_os_x_automation_with_lua/)
 
 Hammerspoon is a tool for powerful automation of OS X. At its core, Hammerspoon is just a bridge between the operating system and a Lua scripting engine. What gives Hammerspoon its power is a set of extensions that expose specific pieces of system functionality, to the user.
 
-###17:00 - Lmod: Building a Community around an Environment Modules Tool
-####Robert McLay	
+### 17:00 - Lmod: Building a Community around an Environment Modules Tool
+#### Robert McLay	
 [Read full abstract](https://fosdem.org/2016/schedule/event/lmod_building_a_community_around_an_environment_modules_tool/)
 
 On today's supercomputers, chemists, biologists, physicists and engineers are sharing the same system and they all need different software. Environment Modules have been the way since the '90 that users select the software they need. They allow users to load and unload the packages they want. They get to control which version of the software they use, rather than the system administrators. Lmod, implemented in Lua, is a modern replacement for the venerable TCL/C based tool. Lmod offers many features to handle the vastly more dynamic software environment than the original tool was designed to handle.
 
-###17:30 - LGSL: Numerical algorithms for Lua - A Lua-ish interface to the GNU Scientific Library
-####Lesley De Cruz	
+### 17:30 - LGSL: Numerical algorithms for Lua - A Lua-ish interface to the GNU Scientific Library
+#### Lesley De Cruz	
 [Read full abstract](https://fosdem.org/2016/schedule/event/lgsl_numerical_algorithms_for_lua_based_on_the_gnu_scientific_library/)
 
 LGSL is a collection of numerical algorithms and functions for Lua, based on the GNU Scientific Library (GSL). It allows matrix and vector manipulation, linear algebra operations, special functions, and much more. LGSL is based on the numerical modules of GSL Shell, and requires LuaJIT.
 
 In this talk, I will demonstrate the features of LGSL and discuss how it was tuned to be blazingly fast thanks to LuaJIT.
 
-###17:50 - What we learned: Developing the Prosody XMPP server in Lua - Lessons learned, regrets, and hopes for the future	
-####Matthew Wild	
+### 17:50 - What we learned: Developing the Prosody XMPP server in Lua - Lessons learned, regrets, and hopes for the future	
+#### Matthew Wild	
 After nearly 8 years of development, what have we learned from developing an ambitious software project in Lua?
 
 When Prosody began, in 2008, Lua was not an obvious choice for developing a real-time network service. Compared to alternative languages, Lua had a poor ecosystem (and some say, still has). Node.js was not yet born, and the world was not used to the idea of serious high-performance services being written in high-level "scripting" languages.
@@ -120,12 +120,12 @@ Many things have changed since that time, both in the Lua world and beyond. "Why
 
 We faced challenges along the way, and learned a lot. This talk examines some events in our project's history as they relate to the Lua language.
 
-###18:20 - Design and Implementation of the MoonGen Packet Generator - Using Lua for high-speed network testing and benchmarking	
-####Paul Emmerich	
+### 18:20 - Design and Implementation of the MoonGen Packet Generator - Using Lua for high-speed network testing and benchmarking	
+#### Paul Emmerich	
 MoonGen is a scriptable high-speed packet generator suitable to test network devices with millions of packets per second at rates of above 10 Gbit/s. Each packet is crafted in real time by a user-defined Lua script to ensure the maximum possible flexibility. MoonGen is available as free and open source software on GitHub, a scientific paper describing it was published at the Internet Measurement Conference in October 2015.
 
-###18:40 - Tarantool: an in-memory NoSQL database and execution grid	
-####Konstantin Osipov	
+### 18:40 - Tarantool: an in-memory NoSQL database and execution grid	
+#### Konstantin Osipov	
 [Read full abstract](https://fosdem.org/2016/schedule/event/tarantool_an_in_memory_nosql_database_and_execution_grid/)
 
 In my talk I will focus on a practical use case: task queue application, using Tarantool as an application server and a database.

--- a/posts/general/community-news-2.md
+++ b/posts/general/community-news-2.md
@@ -1,6 +1,6 @@
 ## Meet-ups and conferences!
 
-###Next
+### Next
 
 [<img src="http://luaconf.com/pub/luaconf.png" alt="luaconf logo" width="80px" style="float: right"/>](http://luaconf.com)
 
@@ -11,7 +11,7 @@
 * October 13th-14th 2016 - Lua Workshop, San Francisco
      * [Website](https://www.lua.org/wshop16.html)
 
-###Past
+### Past
 
 * March 8th - 1st Bay Area OpenResty meetup, San Francisco
      * [Meetup page](http://www.meetup.com/Bay-Area-OpenResty-Meetup/)

--- a/posts/general/community-news-3.md
+++ b/posts/general/community-news-3.md
@@ -1,6 +1,6 @@
 ## Meet-ups and conferences!
 
-###Next
+### Next
 
 * March 5th 2017 - Lua/LuaJIT conference, Moscow
      * [Annnouncement](http://lua-users.org/lists/lua-l/2017-02/msg00001.html)
@@ -11,7 +11,7 @@
      * [Call for sponsor](http://luaconf.com/en#partner)
      
 
-###Past
+### Past
 
 * February 4-5th 2017 - Lua Devroom @ FOSDEM 2017, Brussels
      * [Slides and videos](https://fosdem.org/2017/schedule/track/lua/)

--- a/posts/general/contributing-to-lua-space.md
+++ b/posts/general/contributing-to-lua-space.md
@@ -4,13 +4,13 @@ As you know, [Lua.Space](http://lua.space) is a community blog, at least that's 
 
 I have already written a little bit about this on the opening post, and on the "about" page. Since the blog opened, we had some really awesome posts! However, I've been receiving more questions about this, so I've decided to write another post where I'll repeat some of the information I've given before and add more material to it. 
 
-##How to become one of the writers?
+## How to become one of the writers?
 Decide that you want to contribute with a post :)
 
-##What type of content is welcome?
+## What type of content is welcome?
 This blog was created to promote the use of Lua on various levels, both personally and on the industry.
 
-###Topics:
+### Topics:
 
 * General Lua use
      - Tutorials on language aspects
@@ -26,7 +26,7 @@ This blog was created to promote the use of Lua on various levels, both personal
 * Other domains not listed are welcome! We are pretty excited to see Lua being used in different ways!
 	* If you are unsure if the topic would be well received, [open an issue at github](https://github.com/Etiene/lua.space/issues) and ask around :) 
 
-###Format
+### Format
  Follow normal conventions for writing a google article such as having an introduction, adding references whenever possible etc. All posts should be Lua related in some level. Try to raise interesting discussions :) Besides that, the format is pretty flexible. In case you are unsure, you'll find some examples of types of article below. 
  
 #### Some example formats: 
@@ -93,13 +93,13 @@ Example: [http://lua.space/gamedev/using-tiled-maps-in-love](http://lua.space/ga
 	* Post the youtube video, sound cloud url, and resources you deem relevant to the piece
 	* Add code snippets whenever possible
 
-###English & Grammar
+### English & Grammar
 For the moment, the only language used for posting is English (although we may add more languages in the future). Pay attention to orthography and grammar. If English is not your first language, don't refrain from writing, English is not my first language either. If you are insecure about your English level, once you've written the article on your fork, show it to us, so we can help it out. :)
 
-##How to add your post
+## How to add your post
 All posts are written in [markdown](https://help.github.com/articles/markdown-basics/) and are contained in our [git repository](https://github.com/Etiene/lua.space). Inside the `posts` directory you'll find one or multiple other directories which are the categories of our posts. This one, for example, is in [general](https://github.com/Etiene/lua.space/tree/master/posts/general). Code snippets should be added using the 4 space notation and not the ``` notation.  
 
-###Steps
+### Steps
 
 - Fork our [git repository](https://github.com/Etiene/lua.space)
 - Write your post using the [markdown syntax](https://help.github.com/articles/markdown-basics/)
@@ -113,9 +113,9 @@ All posts are written in [markdown](https://help.github.com/articles/markdown-ba
      -  We will never modify your original post unless for typo fixes or if you require to do so 
      -  You'll still own all the copyrights of your post
 
-###How articles are accepted
+### How articles are accepted
 Once you've created your article on your fork and made a pull request, we will read it and decide how to proceed. If you've read the sections above, you have an idea on what's the scope of this blog. If we think your article is good to go, your PR will be immediately accepted and merged. We might feel something could be improved before publishing, like a section that could be described in more details or an important URL is missing, for example. We will, then, give feedback by commenting on the PR so you can address it. :)
 
 If you have a subject but you are unsure on how to present it, you can also open an issue before writing the post. We will discuss and help you elaborate your idea. :) 
 
-###Yay! That is all for now! Have fun writing, we can't wait to see what you have to share with us! :D
+### Yay! That is all for now! Have fun writing, we can't wait to see what you have to share with us! :D

--- a/posts/science/autograd-for-torch.md
+++ b/posts/science/autograd-for-torch.md
@@ -324,10 +324,10 @@ This enables extremely rapid prototyping of the entirety of a model, from how in
 
 More significantly, what’s difficult to benchmark is the time it takes to specify a new model and debug it in either nn or autograd. In our hands, autograd has dramatically sped up our model building by making it extremely easy to try and test out new ideas, without worrying about correct gradients, twisting nn to support architectures it wasn’t originally designed for, or having to build new modules or loss functions. Autograd is now the first tool we reach for when building neural networks, and we hope that you enjoy it!
 
-##Acknowledgments
+## Acknowledgments
 The core work on autograd for Torch was done by [Alex Wiltschko](https://twitter.com/awiltsch), [Clement Farabet](https://twitter.com/clmt), and [Luke Alonso](https://twitter.com/lukedobl). A big thank you to [Kevin Swersky](https://twitter.com/kswersk), [Arjun Maheswaran](https://twitter.com/segmenta), and [Nicolas Koumchatzky](https://twitter.com/nkoumchatzky) for test-driving early beta versions. This project would not have been possible without the original version of autograd for Python, written by Dougal Maclaurin, [David Duvenaud](https://twitter.com/DavidDuvenaud) and Matt Johnson.
 
-##References
+## References
 [1] Dougal Maclaurin, David Duvenaud, Matt Johnson, “Autograd: Reverse-mode differentiation of native Python”
 
 [2] autograd for Python [https://github.com/HIPS/autograd](https://github.com/HIPS/autograd)

--- a/posts/webdev/the-best-lua-web-frameworks.md
+++ b/posts/webdev/the-best-lua-web-frameworks.md
@@ -32,11 +32,11 @@ You can make a [pull request to this article](https://github.com/Etiene/lua.spac
 
 Something important to note, there is one advantage that is not listed because it applies to all of them, which is the good performance and small footprint. This is even more enhanced on tools that support LuaJIT.
 
-##Web Frameworks Comparison
-##Micro frameworks
+## Web Frameworks Comparison
+## Micro frameworks
 Cousins in other languages: Flask (Python), Sinatra (Ruby)
 
-###Lapis
+### Lapis
 **Website**: [leafo.net/lapis](http://leafo.net/lapis/)
 
 **Source**: [github.com/leafo/lapis](https://github.com/leafo/lapis)
@@ -61,9 +61,9 @@ Lapis is a framework for OpenResty developed by the same creator of the MoonScri
  - Does not support a big variety of webservers and databases (OpenResty with Postgres and MySQL only, but that should be enough for most projects)
  - Does not support Lua >= 5.2 (As it supports LuaJIT it might support Lua5.1, though)
 
-##MVC frameworks
+## MVC frameworks
 Cousins in other languages: Zend (PHP), Yii (PHP), Rails (Ruby), Django (Python)
-###Sailor
+### Sailor
 **Website**: [sailorproject.org](http://sailorproject.org)
 
 **Source**: [github.com/Etiene/sailor](https://github.com/Etiene/sailor)
@@ -89,7 +89,7 @@ Sailor is a fairly new framework that began as an independent project by the sam
  - It's still in alpha version, things change fast, it's being used in production only by a small number of projects
  - Single person project with not many active contributors
 
-###Orbit
+### Orbit
 
 **Website**: [keplerproject.github.io/orbit](http://keplerproject.github.io/orbit/)
 
@@ -114,9 +114,9 @@ Orbit is maybe the oldest and most stable framework written for Lua developed by
  - The development seems fairly abandoned with no recent updates
  - Compatible with Lua 5.1 only
 
-##Event-driven frameworks
+## Event-driven frameworks
 Cousins in other languages: Node.js (Javascript)
-###Luvit
+### Luvit
 **Website**: [luvit.io](https://luvit.io/)
 
 **Source**:[github.com/luvit/luvit](https://github.com/luvit/luvit)
@@ -140,7 +140,7 @@ Luvit is a port of node.js to Lua that claims to be 2-4 times faster and save up
  - Awful documentation, a quick look can't tell how it really works, or which versions of Lua and which databases it supports
  - Not friendly to developers who aren't already familiarized with Node.js
 
-###TurboLua
+### TurboLua
 **Website**: [turbolua.org](http://turbolua.org)
 
 **Source**: [github.com/kernelsauce/turbo](https://github.com/kernelsauce/turbo)
@@ -164,8 +164,8 @@ Turbo is a framework for building event-driven, non-blocking RESTful web applica
  - I couldn't find information on community
  - I couldn't find information on databases supported
 
-##CMS, Wikis & others
-###Ophal
+## CMS, Wikis & others
+### Ophal
 **Website**: [ophal.org](http://ophal.org)
 
 **Source**: [github.com/ophal](https://github.com/ophal)
@@ -191,7 +191,7 @@ Ophal is a is a highly scalable web platform and content management system
  - No/small community
  - Single-person project with no other contributors
  
-###LuaPress
+### LuaPress
 **Website**:[luapress.org](http://luapress.org/)
 
 **Source**: [github.com/Fizzadar/Luapress](https://github.com/Fizzadar/Luapress)
@@ -215,7 +215,7 @@ LuaPress is a static blog generator
  - Single person project with no other contributors and little to no community
  - Could be better documented
 
-###Sputnik
+### Sputnik
 **Website**: [spu.tnik.org](http://spu.tnik.org/)
 
 **Source**: [github.com/yuri/sputnik/](https://github.com/yuri/sputnik/)
@@ -235,7 +235,7 @@ Sputnik is an extensible Wiki
  - Compatible only with Lua5.1
  - Very old abandoned project, it's no longer maintained
 
-###Others
+### Others
 
  - [**Tir**](https://github.com/mongrel2/Tir)
  - [**Lusty**](https://github.com/Olivine-Labs/lusty)
@@ -295,5 +295,5 @@ Sputnik is an extensible Wiki
 </table>
 </center>
 
-###Extra
+### Extra
 My talk on web development in Lua and a Sailor introduction during CodingSerbia 2015: [Link](https://www.youtube.com/watch?v=JGPvM-50bOk)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
